### PR TITLE
Improve notification action callback

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/ActionBroadcastReceiver.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/ActionBroadcastReceiver.java
@@ -22,6 +22,8 @@ import java.util.Map;
 public class ActionBroadcastReceiver extends BroadcastReceiver {
   public static final String ACTION_TAPPED =
       "com.dexterous.flutterlocalnotifications.ActionBroadcastReceiver.ACTION_TAPPED";
+  public static final String ACTION_ID = "actionId";
+  public static final String NOTIFICATION_ID = "notificationId";
 
   @Nullable private static ActionEventSink actionEventSink;
 
@@ -29,11 +31,11 @@ public class ActionBroadcastReceiver extends BroadcastReceiver {
 
   @Override
   public void onReceive(Context context, Intent intent) {
-    final String id = intent.getStringExtra("id");
 
     final Map<String, Object> action = new HashMap<>();
-    action.put("id", id);
-
+    action.put("notificationId", intent.getIntExtra(NOTIFICATION_ID, -1));
+    action.put(
+        "actionId", intent.hasExtra(ACTION_ID) ? intent.getStringExtra(ACTION_ID) : "unknown");
     action.put("payload", intent.hasExtra("payload") ? intent.getStringExtra("payload") : "");
 
     Bundle remoteInput = RemoteInput.getResultsFromIntent(intent);

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -234,7 +234,7 @@ public class FlutterLocalNotificationsPlugin
                 .putExtra("id", action.id)
                 .putExtra(PAYLOAD, notificationDetails.payload);
         PendingIntent actionPendingIntent =
-            PendingIntent.getBroadcast(context, requestCode++, actionIntent, 0);
+            PendingIntent.getBroadcast(context, requestCode++, actionIntent, PendingIntent.FLAG_ONE_SHOT);
         Builder actionBuilder = new Builder(icon, action.title, actionPendingIntent);
 
         if (action.contextual != null) {

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -231,10 +231,12 @@ public class FlutterLocalNotificationsPlugin
         Intent actionIntent =
             new Intent(context, ActionBroadcastReceiver.class)
                 .setAction(ActionBroadcastReceiver.ACTION_TAPPED)
-                .putExtra("id", action.id)
+                .putExtra(ActionBroadcastReceiver.NOTIFICATION_ID, notificationDetails.id)
+                .putExtra(ActionBroadcastReceiver.ACTION_ID, action.id)
                 .putExtra(PAYLOAD, notificationDetails.payload);
         PendingIntent actionPendingIntent =
-            PendingIntent.getBroadcast(context, requestCode++, actionIntent, PendingIntent.FLAG_ONE_SHOT);
+            PendingIntent.getBroadcast(
+                context, requestCode++, actionIntent, PendingIntent.FLAG_ONE_SHOT);
         Builder actionBuilder = new Builder(icon, action.title, actionPendingIntent);
 
         if (action.contextual != null) {

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -48,12 +48,12 @@ class ReceivedNotification {
 
 String? selectedNotificationPayload;
 
-void notificationTapBackground(String id, String? input, String? payload) {
-  // ignore: avoid_print
-  print('notification action tapped: $id with payload: $payload');
-  if (input?.isNotEmpty ?? false) {
+void notificationTapBackground(NotificationActionDetails details) {
+  print(
+      'notification(${details.id}) action tapped: ${details.actionId} with payload: ${details.payload}');
+  if (details.input?.isNotEmpty ?? false) {
     // ignore: avoid_print
-    print('notification action tapped with input: $input');
+    print('notification action tapped with input: ${details.input}');
   }
 }
 
@@ -915,8 +915,8 @@ class _HomePageState extends State<HomePage> {
       iOS: iosNotificationDetails,
     );
     await flutterLocalNotificationsPlugin.show(
-        0, 'plain title', 'plain body', platformChannelSpecifics,
-        payload: 'item x');
+        112, 'plain title', 'plain body', platformChannelSpecifics,
+        payload: 'item z');
   }
 
   Future<void> _showNotificationWithTextAction() async {

--- a/flutter_local_notifications/example/pubspec.yaml
+++ b/flutter_local_notifications/example/pubspec.yaml
@@ -9,10 +9,6 @@ dependencies:
     sdk: flutter
   flutter_local_notifications:
     path: ../
-  flutter_local_notifications_platform_interface:
-    path: ../../flutter_local_notifications_platform_interface/
-  flutter_local_notifications_linux:
-    path: ../../flutter_local_notifications_linux/
   flutter_native_timezone: ^2.0.0
   http: ^0.13.4
   image: ^3.0.8
@@ -27,6 +23,12 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
+
+dependency_overrides: 
+  flutter_local_notifications_platform_interface:
+    path: ../../flutter_local_notifications_platform_interface/
+  flutter_local_notifications_linux:
+    path: ../../flutter_local_notifications_linux/
 
 flutter:
   uses-material-design: true

--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -1091,7 +1091,8 @@ static FlutterError *getFlutterError(NSError *error) {
     }
 
     [actionEventSink addItem:@{
-      @"id" : response.actionIdentifier,
+      @"notificationId" : response.notification.request.identifier,
+      @"actionId" : response.actionIdentifier,
       @"input" : text,
       @"payload" : response.notification.request.content.userInfo[@"payload"],
     }];

--- a/flutter_local_notifications/lib/flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/flutter_local_notifications.dart
@@ -4,7 +4,8 @@ export 'package:flutter_local_notifications_platform_interface/flutter_local_not
         SelectNotificationCallback,
         PendingNotificationRequest,
         RepeatInterval,
-        NotificationAppLaunchDetails;
+        NotificationAppLaunchDetails,
+        NotificationActionDetails;
 
 export 'src/flutter_local_notifications_plugin.dart';
 export 'src/initialization_settings.dart';

--- a/flutter_local_notifications/lib/src/callback_dispatcher.dart
+++ b/flutter_local_notifications/lib/src/callback_dispatcher.dart
@@ -28,7 +28,21 @@ void callbackDispatcher() {
         .map<Map<String, dynamic>>(
             (Map<dynamic, dynamic> event) => Map.castFrom(event))
         .listen((Map<String, dynamic> event) {
-      callback?.call(event['id'], event['input'], event['payload']);
+      final Object notificationId = event['notificationId'];
+      final int id;
+      if (notificationId is int) {
+        id = notificationId;
+      } else if (notificationId is String) {
+        id = int.parse(notificationId);
+      } else {
+        id = -1;
+      }
+      callback?.call(NotificationActionDetails(
+        id: id,
+        actionId: event['actionId'],
+        input: event['input'],
+        payload: event['payload'],
+      ));
     });
   });
 }

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_local_notifications_linux: ^0.3.0
-  flutter_local_notifications_platform_interface: ^5.0.0
+  flutter_local_notifications_platform_interface: ^6.0.0
   timezone: ^0.8.0
 
 dev_dependencies:

--- a/flutter_local_notifications_linux/pubspec.yaml
+++ b/flutter_local_notifications_linux/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flut
 dependencies:
   flutter:
     sdk: flutter
-  flutter_local_notifications_platform_interface: ^5.0.0
+  flutter_local_notifications_platform_interface: ^6.0.0
   dbus: ^0.5.0
   path: ^1.8.0
   xdg_directories: ^0.2.0

--- a/flutter_local_notifications_platform_interface/lib/src/typedefs.dart
+++ b/flutter_local_notifications_platform_interface/lib/src/typedefs.dart
@@ -1,7 +1,10 @@
+import 'types.dart';
+
 /// Signature of callback passed to [initialize] that is triggered when user
 /// taps on a notification.
 typedef SelectNotificationCallback = void Function(String? payload);
 
 /// Callback function when a notification is received.
 typedef NotificationActionCallback = void Function(
-    String id, String? input, String? payload);
+  NotificationActionDetails details,
+);

--- a/flutter_local_notifications_platform_interface/lib/src/types.dart
+++ b/flutter_local_notifications_platform_interface/lib/src/types.dart
@@ -31,3 +31,26 @@ class PendingNotificationRequest {
   /// The notification's payload.
   final String? payload;
 }
+
+/// Details of a Notification Action that was triggered.
+class NotificationActionDetails {
+  /// Constructs an instance of [NotificationActionDetails]
+  NotificationActionDetails({
+    required this.id,
+    required this.actionId,
+    required this.input,
+    required this.payload,
+  });
+
+  /// The notification's id.
+  final int id;
+
+  /// The id of the action that was triggered.
+  final String actionId;
+
+  /// The value of the input field if the notification action had an input field.
+  final String? input;
+
+  /// The notification's payload
+  final String? payload;
+}

--- a/flutter_local_notifications_platform_interface/pubspec.yaml
+++ b/flutter_local_notifications_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_local_notifications_platform_interface
 description: A common platform interface for the flutter_local_notifications plugin.
-version: 5.0.0
+version: 6.0.0
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications_platform_interface
 
 environment:


### PR DESCRIPTION
This PR adds two things:

1. Fix for the android intent getting reused and thus not updating
2. A new `NotificationActionDetails` class that gives more data to the user in the background handler